### PR TITLE
feat: allow to pass extra envs to pod

### DIFF
--- a/charts/dafka-consumer/Chart.yaml
+++ b/charts/dafka-consumer/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm Chart for Dafka Consumer
 name: dafka-consumer
-version: 7.3.0
+version: 7.3.1

--- a/charts/dafka-consumer/templates/deployment.yaml
+++ b/charts/dafka-consumer/templates/deployment.yaml
@@ -124,6 +124,12 @@ spec:
             {{- end }}
             {{- end }}
         {{- end }}
+            {{- if .Values.env }}
+            {{- range $k, $v := .Values.env}}
+            - name: {{ $k }}
+              value: {{ $v }}
+            {{- end }}
+            {{- end }}
           livenessProbe:
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             httpGet:

--- a/charts/dafka-consumer/values.yaml
+++ b/charts/dafka-consumer/values.yaml
@@ -122,3 +122,6 @@ podMonitor:
 pdb:
   # -- Set to true to enable
   enabled: false
+
+# -- Extra envs to add to pod
+env:


### PR DESCRIPTION
Instead of exposing each consumer config allow to pass any env var the user need