### PR TITLE
chore: bump dafka-consumer chart to 13.3.1, image tag 13.3

### DIFF
--- a/charts/dafka-consumer/Chart.yaml
+++ b/charts/dafka-consumer/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm Chart for Dafka Consumer
 name: dafka-consumer
-version: 13.2.3
+version: 13.3.1

--- a/charts/dafka-consumer/README.md
+++ b/charts/dafka-consumer/README.md
@@ -1,6 +1,6 @@
 # dafka-consumer
 
-![Version: 13.2.3](https://img.shields.io/badge/Version-13.2.3-informational?style=flat-square)
+![Version: 13.3.1](https://img.shields.io/badge/Version-13.3.1-informational?style=flat-square)
 
 A Helm Chart for Dafka Consumer
 
@@ -15,7 +15,7 @@ A Helm Chart for Dafka Consumer
 | replicaCount | int | `1` | pod count |
 | batchParallelismFactor | int | `1` |  |
 | image.name | string | `"osskit/dafka-consumer"` | the image name to use |
-| image.tag | string | `"13.2"` | the image tag to use |
+| image.tag | string | `"13.3"` | the image tag to use |
 | logLevel | string | `"WARN"` | Allow to specify log level |
 | retryPolicyExponentialBackoff | string | `"50,5000,2"` |  |
 | assignmentStrategy | string | `"CooperativeSticky"` | The assignment strategies list (comma separated list of: Range, RoundRobin, Sticky, CooperativeSticky) |

--- a/charts/dafka-consumer/values.yaml
+++ b/charts/dafka-consumer/values.yaml
@@ -19,7 +19,7 @@ image:
   # -- the image name to use
   name: osskit/dafka-consumer
   # -- the image tag to use
-  tag: "13.2"
+  tag: "13.3"
 
 # -- Allow to specify log level
 logLevel: WARN


### PR DESCRIPTION
Bump chart version to 13.3.1 and default image tag to `13.3` (minor only so consumers get patch fixes 13.3.x automatically).

Includes NPE fix from dafka-consumer PR #116 (null response in HttpTarget when target times out or returns 503).

Made with [Cursor](https://cursor.com)